### PR TITLE
Make spectrograms consume less memory and load faster

### DIFF
--- a/R/mod_match_calls.R
+++ b/R/mod_match_calls.R
@@ -165,15 +165,14 @@ mod_match_calls_server <- function(id, r){
     ## Observe changes to the row ids shown on the current page
     observeEvent(input$unmatched_calls_rows_current, {
       req(frontendData())
-      # array of base64 images and the frontend row index they correspond to
+      # named list of base64 images where name is the row_id-1 and value is base64 string.
       encodedImages <- list()
+      added_rows <- FALSE # flag to check if any new rows were processed
       ## For each row that is visible on the current page of the table
-      added_rows <- 0
       for (i in input$unmatched_calls_rows_current) {
         key <- as.character(i-1)
-          if (isFALSE(key %in% processedRows)) {
+          if (key %not_in% processedRows) {
             golem::print_dev(paste("ADDING KEY", key))
-            #golem::print_dev(encodedImages)
           # Get row from backend using frontend row id.
           backendRecID <- frontendData() %>%
             slice(i) %>%
@@ -204,13 +203,16 @@ mod_match_calls_server <- function(id, r){
 
             #i minus one since array indexing in javascript begins at zero (like any other normal language!)
             encodedImages[[key]] <- b64data #list(rowId = i-1, src=b64data)
-            added_rows <- added_rows + 1
+
             # Mark this row as processed
             processedRows <<- c(processedRows, key)
+            if (!added_rows) {
+              added_rows <- TRUE
+            }
           }
           }
       }
-      if (added_rows > 0) { # Only inform the client of new spectrogram images, not old ones.
+      if (added_rows) { # Only inform the client of new spectrogram images, not old ones.
         # Send JSON object to client of format {rowId <string> : base64Image <string>}
         session$sendCustomMessage("updateTableSpectrogramImages", encodedImages)
       }

--- a/R/mod_match_calls.R
+++ b/R/mod_match_calls.R
@@ -167,10 +167,11 @@ mod_match_calls_server <- function(id, r){
       req(frontendData())
       # named list of base64 images where name is the row_id-1 and value is base64 string.
       encodedImages <- list()
+      idx <- 1
       added_rows <- FALSE # flag to check if any new rows were processed
       ## For each row that is visible on the current page of the table
       for (i in input$unmatched_calls_rows_current) {
-        key <- as.character(i-1)
+        key <- i-1
           if (key %not_in% processedRows) {
             golem::print_dev(paste("ADDING KEY", key))
           # Get row from backend using frontend row id.
@@ -202,18 +203,19 @@ mod_match_calls_server <- function(id, r){
             b64data <- encode_image(spectroAbsPath)
 
             #i minus one since array indexing in javascript begins at zero (like any other normal language!)
-            encodedImages[[key]] <- b64data #list(rowId = i-1, src=b64data)
+            encodedImages[[idx]] <- list(rowId = key, src=b64data)
 
             # Mark this row as processed
             processedRows <<- c(processedRows, key)
             if (!added_rows) {
               added_rows <- TRUE
             }
+            idx <- idx + 1
           }
           }
       }
       if (added_rows) { # Only inform the client of new spectrogram images, not old ones.
-        # Send JSON object to client of format {rowId <string> : base64Image <string>}
+        # Send JSON array to client of format [ {rowId: <num>, src: <base64string>} ]
         session$sendCustomMessage("updateTableSpectrogramImages", encodedImages)
       }
     })

--- a/inst/app/www/client_datatable_logic.js
+++ b/inst/app/www/client_datatable_logic.js
@@ -78,15 +78,17 @@ $( document ).ready(function() {
 
 function refreshTableImages(table) {
   console.log("REFRESHING IMAGES");
-  console.log(Object.keys(spectroImages))
+  console.log(Object.keys(spectroImages));
   let invalidated = false;
-  table.column("spectrogram:name").nodes().each(function(cell, i) {
-    if (typeof spectroImages[i] !== "undefined") {
-      table.cell(cell).data(`<img src=${spectroImages[i]} width="50px">`);
-      table.cell(cell).invalidate();
-      invalidated = true;
-    }
-  });
+
+  // Update and invalidate all the cells whose rows are specified in spectroImages
+  for (const [key, value] of Object.entries(spectroImages)) {
+    const row = parseInt(key);
+    table.cell(row, "spectrogram:name")
+      .data(`<img src=${value} width="50px">`)
+      .invalidate();
+    invalidated = true;
+  }
   if (invalidated) {
     table.draw(false);
   }

--- a/inst/app/www/client_datatable_logic.js
+++ b/inst/app/www/client_datatable_logic.js
@@ -60,13 +60,18 @@ $( document ).ready(function() {
     }
   });
 
-  Shiny.addCustomMessageHandler('updateTableSpectrogramImages', function(arr) {
-    for (const imageObj of arr) {
+  Shiny.addCustomMessageHandler('updateTableSpectrogramImages', function(obj) {
+
+    let updated = false;
+    Object.keys(obj).forEach(function (key) {
+      const base64Img = obj[key];
+      const rowId = parseInt(key);
       //Update the state of spectrogram images
-      spectroImages[imageObj.rowId] = imageObj.src;
-    }
-    // Update the images if the table has loaded
-    if (hasTableLoaded()) {
+      spectroImages[rowId] = base64Img;
+      updated = true;
+    });
+    // Update the images if new images have been added and the table has finished loading.
+    if (updated && hasTableLoaded()) {
       refreshTableImages(getTable());
     }
   });

--- a/inst/app/www/client_datatable_logic.js
+++ b/inst/app/www/client_datatable_logic.js
@@ -92,6 +92,18 @@ function refreshTableImages(table) {
   if (invalidated) {
     table.draw(false);
   }
+  //Empty the spectrograms object to save memory
+  //We can retrieve the downloaded spectrogram images from the table
+  spectroImages = {};
+}
+
+function getSpectroImageByRow(row) {
+  const table = getTable();
+  // Access the data directly from the cell
+  const cellData = table.cell(row, "spectrogram:name").node();
+  // Extract the src attribute from the first child if it exists
+  const imgSrc = cellData.querySelector("img")?.getAttribute("src");
+  return imgSrc || null;
 }
 
 function registerCheckboxListeners(table) {

--- a/inst/app/www/client_datatable_logic.js
+++ b/inst/app/www/client_datatable_logic.js
@@ -60,16 +60,15 @@ $( document ).ready(function() {
     }
   });
 
-  Shiny.addCustomMessageHandler('updateTableSpectrogramImages', function(obj) {
-
+  Shiny.addCustomMessageHandler('updateTableSpectrogramImages', function(arr) {
     let updated = false;
-    Object.keys(obj).forEach(function (key) {
-      const base64Img = obj[key];
-      const rowId = parseInt(key);
+    for (const imageObj of arr) {
       //Update the state of spectrogram images
-      spectroImages[rowId] = base64Img;
-      updated = true;
-    });
+      spectroImages[imageObj.rowId] = imageObj.src;
+      if (!updated) {
+        updated = true;
+      }
+    }
     // Update the images if new images have been added and the table has finished loading.
     if (updated && hasTableLoaded()) {
       refreshTableImages(getTable());

--- a/inst/app/www/show_spectrograms.js
+++ b/inst/app/www/show_spectrograms.js
@@ -1,13 +1,14 @@
 $( document ).ready(function() {
   // Click event listener for the show spectrograms button
+
   $("#show_spectrograms").on("click", function() {
-    if ((typeof checkboxState !== "undefined") && (typeof spectroImages !== "undefined")) {
+    if (typeof checkboxState !== "undefined") {
 
       //Create array of [<row_id>, <associated spectrogram image>]
       const checkedImages = Object.entries(checkboxState)
       .filter(state => state[1])//filter by checked : true
       .map(state => state[0]) // extract only row ids
-      .map(id => [parseInt(id), spectroImages[id]]);
+      .map(id => [parseInt(id), getSpectroImageByRow(id)]);
 
         console.log(checkedImages);
       // Generate new HTML content


### PR DESCRIPTION
This PR reduces the memory consumption of spectrograms.
Specifically:

1. The server sends only spectrogram images of new rows, and not all the images each time the visible rows change
2. The server does not store the base64 encodings of spectrograms.
3. The server stores only the indices of rows which have had their spectrogram images read and encoded as base64.

(3) allows us to do (1).