### PR TITLE
Improve performance of time difference calculation

### DIFF
--- a/R/mod_match_calls.R
+++ b/R/mod_match_calls.R
@@ -101,11 +101,7 @@ mod_match_calls_server <- function(id, r){
         options = list(
           paging = TRUE,    ## paginate the output
           pageLength = 15,  ## number of rows to output for each page
-          scrollX = TRUE,   ## enable scrolling on X axis
-          scrollY = TRUE,   ## enable scrolling on Y axis
           autoWidth = TRUE, ## use smart column width handling
-          scrollY =  20,
-          scrollCollapse = TRUE,
           searching = TRUE,
           columnDefs = list(
             list(visible=FALSE, targets=1)


### PR DESCRIPTION
This PR drastically improves the responsiveness of the table when clicking on a row to populate the timediff column.

1. Invalidate only the cells of the time difference column instead of all the rows when the user clicks on a row to calculate the time difference.
2. Reset the values of the timediff column back to "-" ONLY when the user clicks on the last selected row.
3. Use table.column().nodes() instead of table.rows().every for faster performance
4. Remove scrollX and scrollY parameters as they cause the datatable to freeze when the table is re-painted.

